### PR TITLE
Move settings to dynaconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,8 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/python,pycharm+all
+Include/
+
+Scripts/
+
+tcl/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-# SLFF-Drafter specific
+﻿# SLFF-Drafter specific
 
 keys.py
 credentials.json
 token.pickle
+config/\.secrets\*
+
 
 # =====================================================================================================================
 
@@ -223,7 +225,6 @@ dmypy.json
 
 # End of https://www.gitignore.io/api/python,pycharm+all
 Include/
-
 Scripts/
-
 tcl/
+

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 Requires Python 3.6+ (may work on earlier versions, we dunno)
 
-Create a file named `keys.py` in the root directory of the project that contains your Discord Bot token:
+Create a file in the `config` folder named `.secrets.yaml`, insert the following code block, and store your Discord bot token:
 
-```python
-DISCORD_TOKEN = "my_discord_token"
+```yaml
+default:	
+    discord:	
+        token: "YOUR_TOKEN_HERE" 
 ```
 
 Go to this page and enable the Google Sheets API in order to download a `credentials.json` file:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Create a file in the `config` folder named `.secrets.yaml`, insert the following
 ```yaml
 default:	
     discord:	
-        token: "YOUR_TOKEN_HERE" 
+        token: YOUR_TOKEN_HERE
+        dynaconf_merge: true 
 ```
 
 Go to this page and enable the Google Sheets API in order to download a `credentials.json` file:

--- a/bot.py
+++ b/bot.py
@@ -4,18 +4,13 @@ from typing import Dict
 import discord
 from discord.ext import commands
 from tabulate import tabulate
-
-from keys import DISCORD_TOKEN
+from dynaconf import settings
 from models.draft import Draft
-
-BOT_USER_ID = 573557278695882762
-
-REGISTER_EMOJI = u"\U0001F44D"
 
 Client = discord.Client()
 bot = commands.Bot(command_prefix=".")
 
-# tba = tbapy.TBA('9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb')
+# tba = tbapy.TBA(settings.tba.api_key)
 
 nextIdNum = 1
 
@@ -57,7 +52,6 @@ async def ping(ctx):
     Example: .init "MidKnight Mayhem" 2019-05-02 12:00 15:00
 """
 
-
 # TODO fix this broken function
 @bot.command(pass_context=True)
 async def test(ctx):
@@ -76,7 +70,7 @@ async def init(ctx, event_name, draft_date, reg_close_time, draft_begin_time):
         reg_close_time_dt = datetime.datetime.strptime(reg_close, '%Y-%m-%d %H:%M %z')
         reg_close_time_dt += datetime.timedelta(hours=12)
     except ValueError:
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `init`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `init`")
         embed.add_field(
             name='Invalid date or time for registration close',
             value="Please check your date and/or time to close registration and try again",
@@ -89,7 +83,7 @@ async def init(ctx, event_name, draft_date, reg_close_time, draft_begin_time):
         draft_begin_time_dt = datetime.datetime.strptime(draft_begin, '%Y-%m-%d %H:%M %z')
         draft_begin_time_dt += datetime.timedelta(hours=12)
     except ValueError:
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `init`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `init`")
         embed.add_field(
             name='Invalid date or time for draft beginning',
             value="Please check your date and/or time to begin the draft and try again",
@@ -111,24 +105,24 @@ async def init(ctx, event_name, draft_date, reg_close_time, draft_begin_time):
     readable_draft_begin_time = get_readable_datetime(draft_begin_time_dt)
 
     title_msg = f'Created draft for "{event_name}" [id: {draft_key}]'
-    embed = discord.Embed(color=0xe8850d, title=title_msg)
-    embed.add_field(name='To register for this draft:', value=f'React to this message with {REGISTER_EMOJI}')
+    embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title=title_msg)
+    embed.add_field(name='To register for this draft:', value=f'React to this message with {settings.DISCORD.REGISTER_EMOJI}')
     embed.add_field(name='Registration closes at:', value=readable_reg_close_time, inline=False)
     embed.add_field(name='Draft starts at:', value=readable_draft_begin_time, inline=False)
-    embed.set_thumbnail(url='https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png')
+    embed.set_thumbnail(url=settings.DISCORD.THUMBNAIL)
 
     sent = await ctx.send(embed=embed)
 
     draft.set_join_message_id(sent.id)
     drafts[draft_key] = draft
 
-    await sent.add_reaction(REGISTER_EMOJI)
+    await sent.add_reaction(settings.DISCORD.REGISTER_EMOJI)
 
 
 @bot.command(pass_context=True)
 async def add_teams(ctx, draft_key, *args):
     if draft_key not in drafts:
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `.addteams`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `.addteams`")
         embed.add_field(
             name='Invalid draft key',
             value="Please check your draft key and try again",
@@ -137,7 +131,7 @@ async def add_teams(ctx, draft_key, *args):
         await ctx.send(embed=embed)
         return
     if not drafts[draft_key].add_teams(args):
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `.addteams`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `.addteams`")
         embed.add_field(
             name='Invalid team number(s)',
             value="Please check your team list and try again",
@@ -147,7 +141,7 @@ async def add_teams(ctx, draft_key, *args):
         return
     new_teams = ", ".join(str(t) for t in args)
     team_list = ", ".join(drafts[draft_key].get_team_list())
-    embed = discord.Embed(color=0xe8850d, title=f"Successfully updated [{draft_key}]")
+    embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title=f"Successfully updated [{draft_key}]")
     embed.add_field(
         name='Team List',
         value=f'{team_list}',
@@ -159,7 +153,7 @@ async def add_teams(ctx, draft_key, *args):
 @bot.command(pass_context=True)
 async def remove_teams(ctx, draft_key, *args):
     if draft_key not in drafts:
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `.removeteams`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `.removeteams`")
         embed.add_field(
             name='Invalid draft key',
             value="Please check your draft key and try again",
@@ -168,7 +162,7 @@ async def remove_teams(ctx, draft_key, *args):
         await ctx.send(embed=embed)
         return
     if not drafts[draft_key].remove_teams(args):
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `.removeteams`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `.removeteams`")
         embed.add_field(
             name='Invalid team number(s)',
             value="Please check your team list and try again",
@@ -178,7 +172,7 @@ async def remove_teams(ctx, draft_key, *args):
         return
     newTeams = ", ".join(str(t) for t in args)
     teamList = ", ".join(drafts[draft_key].get_team_list())
-    embed = discord.Embed(color=0xe8850d, title=f"Successfully removed from team list for [{draft_key}]")
+    embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title=f"Successfully removed from team list for [{draft_key}]")
     embed.add_field(
         name='Removed {}'.format(newTeams),
         value="New team list: {}".format(teamList),
@@ -192,7 +186,7 @@ async def set_key(ctx, draft_key, event_key):
     if draft_key in drafts:
         drafts[draft_key].set_event_key(event_key)
         name = drafts[draft_key].get_name()
-        embed = discord.Embed(color=0xe8850d, title="TBA key for {} set".format(name))
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="TBA key for {} set".format(name))
         embed.add_field(
             name=f'TBA Key for {name} [{draft_key}] is now {event_key}',
             value=f"Either key can be used to reference {name}",
@@ -200,7 +194,7 @@ async def set_key(ctx, draft_key, event_key):
         )
         await ctx.send(embed=embed)
     else:
-        embed = discord.Embed(color=0xe8850d, title="ERROR in `.setkey`")
+        embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title="ERROR in `.setkey`")
         embed.add_field(
             name=f'No draft found with key [{draft_key}]',
             value="Please check your draft key and try again",
@@ -252,7 +246,7 @@ async def start(ctx, draft_key):
 
     team_list = draft.get_team_square()
 
-    embed = discord.Embed(color=0xe8850d, title=event_name)
+    embed = discord.Embed(color=settings.DISCORD.TITLE_COLOR, title=event_name)
     embed.add_field(name='Picks', value=f'```{tabulate(table, headers, tablefmt="presto")}```',
                     inline=True)
     embed.add_field(name='Available', value=f'```{tabulate(team_list)}```')
@@ -285,12 +279,12 @@ async def get_participants_from_reacts(ctx, draft):
     msg = await ctx.fetch_message(msg_id)
     participants = []
     for reaction in msg.reactions:
-        if reaction.emoji == REGISTER_EMOJI:
+        if reaction.emoji == settings.DISCORD.REGISTER_EMOJI:
             async for user in reaction.users():
-                if user.id != BOT_USER_ID:
+                if user.id != settings.DISCORD.BOT_USER_ID:
                     participants.append(user.id)
     return participants
 
 
 if __name__ == "__main__":
-    bot.run(DISCORD_TOKEN)
+    bot.run(settings.DISCORD.TOKEN)

--- a/config/.secrets.yaml
+++ b/config/.secrets.yaml
@@ -1,0 +1,3 @@
+default:
+    discord:
+        token: ""

--- a/config/.secrets.yaml
+++ b/config/.secrets.yaml
@@ -1,3 +1,0 @@
-default:
-    discord:
-        token: ""

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -7,6 +7,7 @@ default:
         register_emoji: "\U0001F44D"
         thumbnail: 'https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png'
         title_color: 0xe8850d
+        dynaconf_merge: true
 
     google:
         scopes: ['https://www.googleapis.com/auth/spreadsheets']

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,25 +1,25 @@
 default:
     tba:
-        api_key: "9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb"
+        api_key: 9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb
 
     discord:
         bot_user_id: 573557278695882762
-        register_emoji: "\U0001F44D"
-        thumbnail: 'https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png'
+        register_emoji: \U0001F44D
+        thumbnail: https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png
         title_color: 0xe8850d
         dynaconf_merge: true
 
     google:
         scopes: ['https://www.googleapis.com/auth/spreadsheets']
-        creds_cache_filename: 'token.pickle'
-        credentials_json: 'credentials.json'
+        creds_cache_filename: token.pickle
+        credentials_json: credentials.json
 
     draft:
-        data_store_spreadsheet_id: '1rvjsDfInf9KWFUwwVjDwz2ZADeD_4Fx3LMmNws7exss'
+        data_store_spreadsheet_id: 1rvjsDfInf9KWFUwwVjDwz2ZADeD_4Fx3LMmNws7exss
         max_picks: 3
 
     elasticsearch:
-        url_base: 'http://es01.usfirst.org'
-        event_list_url: '/events/_search?size=1000&source={"query":{"query_string":{"query":"(event_type:FRC)%%20AND%%20(event_season:%s)"}}}'
-        event_teams_url: '/teams/_search?size=1000&source={"_source":{"exclude":["awards","events"]},"query":{"query_string":{"query":"events.fk_events:%s%%20AND%%20profile_year:%s"}}}'
+        url_base: http://es01.usfirst.org
+        event_list_url: /events/_search?size=1000&source={"query":{"query_string":{"query":"(event_type:FRC)%%20AND%%20(event_season:%s)"}}}
+        event_teams_url: /teams/_search?size=1000&source={"_source":{"exclude":["awards","events"]},"query":{"query_string":{"query":"events.fk_events:%s%%20AND%%20profile_year:%s"}}}
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -4,7 +4,7 @@ default:
 
     discord:
         bot_user_id: 573557278695882762
-        register_emoji: \U0001F44D
+        register_emoji: "\U0001F44D"
         thumbnail: https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png
         title_color: 0xe8850d
         dynaconf_merge: true

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,0 +1,24 @@
+default:
+    tba:
+        api_key: "9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb"
+
+    discord:
+        bot_user_id: 573557278695882762
+        register_emoji: "\U0001F44D"
+        thumbnail: 'https://cdn.discordapp.com/attachments/303583753022865408/539892100737531921/moon.png'
+        title_color: 0xe8850d
+
+    google:
+        scopes: ['https://www.googleapis.com/auth/spreadsheets']
+        creds_cache_filename: 'token.pickle'
+        credentials_json: 'credentials.json'
+
+    draft:
+        data_store_spreadsheet_id: '1rvjsDfInf9KWFUwwVjDwz2ZADeD_4Fx3LMmNws7exss'
+        max_picks: 3
+
+    elasticsearch:
+        url_base: 'http://es01.usfirst.org'
+        event_list_url: '/events/_search?size=1000&source={"query":{"query_string":{"query":"(event_type:FRC)%%20AND%%20(event_season:%s)"}}}'
+        event_teams_url: '/teams/_search?size=1000&source={"_source":{"exclude":["awards","events"]},"query":{"query_string":{"query":"events.fk_events:%s%%20AND%%20profile_year:%s"}}}'
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ attrs==19.1.0
 cachetools==3.1.0
 certifi==2019.3.9
 chardet==3.0.4
+Click==7.0
 discord.py==1.0.1
+dynaconf==2.0.2
 google-api-python-client==1.7.8
 google-auth==1.6.3
 google-auth-httplib2==0.0.3
@@ -16,12 +18,16 @@ multidict==4.5.2
 oauthlib==3.0.1
 pyasn1==0.4.5
 pyasn1-modules==0.2.5
+python-box==3.4.0
+python-dotenv==0.10.2
+PyYAML==5.1
 requests==2.21.0
 requests-oauthlib==1.2.0
 rsa==4.0
 six==1.12.0
 tabulate==0.8.3
 tbapy==1.3.1
+toml==0.10.0
 typing-extensions==3.7.2
 uritemplate==3.0.0
 urllib3==1.24.3

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ from dynaconf import settings
 assert(settings.DISCORD.TOKEN is not None)
 assert(settings.DISCORD.TITLE_COLOR == 0xe8850d)
 assert(settings.TBA.API_KEY == "9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb")
+print("Should be a thumbs up:", settings.DISCORD.REGISTER_EMOJI)
 
 es = FRCES(2019)
 assert(len(es.get_event_teams('2019vabla')) == 34)

--- a/test.py
+++ b/test.py
@@ -1,6 +1,14 @@
 from wrappers.sheets import models
 from wrappers.sheets.api import Spreadsheet
+from wrappers.firstelastic import FRCES
 from dynaconf import settings
+
+assert(settings.DISCORD.TOKEN is not None)
+assert(settings.DISCORD.TITLE_COLOR == 0xe8850d)
+assert(settings.TBA.API_KEY == "9qTowkNEd3IarS0iDGB40d6Gqi4YJDlosHiLeLypQ3XfAEFeBp0bIYSqcBqB3fHb")
+
+es = FRCES(2019)
+assert(len(es.get_event_teams('2019vabla')) == 34)
 
 spreadsheet = Spreadsheet(settings.DRAFT.DATA_STORE_SPREADSHEET_ID)
 print(spreadsheet.event_info.contains_event('foo'))

--- a/test.py
+++ b/test.py
@@ -8,5 +8,5 @@ print(spreadsheet.event_info.contains_event('foo2'))
 spreadsheet.event_info.set_event_info(models.EventInfo('foo', '2019nyro', ['2791', '340', '3015', '5254', '20']))
 print(spreadsheet.event_info.get_event_info('foo'))
 spreadsheet.draft_results.set_pick(models.DraftResults(
-    'justin', 'foo', 1, 1, [models.Pick('8:30 PM', False, '254'), models.Pick('8:33 PM', True, '3044')]
+    'justin', 'foo', 1, 1, [models.Pick('8:30 PM', False, '254'), models.Pick('8:37 PM', True, '3044')]
 ))

--- a/test.py
+++ b/test.py
@@ -1,7 +1,8 @@
 from wrappers.sheets import models
-from wrappers.sheets.api import Spreadsheet, DATA_STORE_SPREADSHEET_ID
+from wrappers.sheets.api import Spreadsheet
+from dynaconf import settings
 
-spreadsheet = Spreadsheet(DATA_STORE_SPREADSHEET_ID)
+spreadsheet = Spreadsheet(settings.DRAFT.DATA_STORE_SPREADSHEET_ID)
 print(spreadsheet.event_info.contains_event('foo'))
 print(spreadsheet.event_info.contains_event('foo2'))
 spreadsheet.event_info.set_event_info(models.EventInfo('foo', '2019nyro', ['2791', '340', '3015', '5254', '20']))

--- a/wrappers/sheets/api.py
+++ b/wrappers/sheets/api.py
@@ -5,22 +5,11 @@ from typing import Union, List, Tuple
 from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
+from dynaconf import settings
 
 from wrappers.sheets import models
 
 # Reference: https://developers.google.com/sheets/api/quickstart/python\
-
-# The ID and range of a sample spreadsheet.
-SAMPLE_SPREADSHEET_ID = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms'
-
-# todo: config
-# If modifying these scopes, delete the file token.pickle.
-SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
-DATA_STORE_SPREADSHEET_ID = '1rvjsDfInf9KWFUwwVjDwz2ZADeD_4Fx3LMmNws7exss'
-CREDS_CACHE_FILENAME = 'token.pickle'
-CREDENTIALS_JSON = 'credentials.json'
-MAX_NUM_PICKS = 3
-
 
 class SheetRange:
     """
@@ -206,7 +195,7 @@ class Spreadsheet:
                                          ['event_id', 'tba_key', 'teams_b64'])
 
         draft_results_headers = ['player', 'event_id', 'tier', 'pick_number']
-        for i in range(1, MAX_NUM_PICKS + 1):
+        for i in range(1, settings.DRAFT.MAX_PICKS + 1):
             draft_results_headers.extend([f'pick{i}_time', f'pick{i}_randomed', f'pick{i}_team'])
 
         self.draft_results = DraftResultsSheet('DraftResults', SheetRange('DraftResults', 'A', None, 'M', None), self,
@@ -220,8 +209,8 @@ class SheetsWrapper:
         # The file token.pickle stores the user's access and refresh tokens, and is
         # created automatically when the authorization flow completes for the first
         # time.
-        if os.path.exists(CREDS_CACHE_FILENAME):
-            with open(CREDS_CACHE_FILENAME, 'rb') as token:
+        if os.path.exists(settings.GOOGLE.CREDS_CACHE_FILENAME):
+            with open(settings.GOOGLE.CREDS_CACHE_FILENAME, 'rb') as token:
                 creds = pickle.load(token)
 
         # If there are no (valid) credentials available, let the user log in.
@@ -229,11 +218,11 @@ class SheetsWrapper:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
             else:
-                flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_JSON, SCOPES)
+                flow = InstalledAppFlow.from_client_secrets_file(settings.GOOGLE.CREDENTIALS_JSON, settings.GOOGLE.SCOPES)
                 creds = flow.run_local_server()
 
             # Save the credentials for next run
-            with open(CREDS_CACHE_FILENAME, 'wb') as token:
+            with open(settings.GOOGLE.CREDS_CACHE_FILENAME, 'wb') as token:
                 pickle.dump(creds, token)
 
         # Build and store objects for future use


### PR DESCRIPTION
Settings for TBA, Elasticsearch, Google, Discord, and draft specific stuff all pulled out of specific files and into a settings file. 

Opted for YAML over TOML for the settings file, currently accessing settings as attributes instead of as dictionary items, can change format if anyone feels strongly.

Readme is updated with instructions for setting up `config/.secrets.yaml` instead of using `keys.py`.